### PR TITLE
Backhandler Changers

### DIFF
--- a/Screens/Dream.tsx
+++ b/Screens/Dream.tsx
@@ -10,10 +10,11 @@ import {
   Modal,
   ActivityIndicator,
   Platform,
+  BackHandler,
 } from 'react-native';
 import {Feather} from '@expo/vector-icons';
 import appColors from '../colors';
-import {useContext, useState} from 'react';
+import {useCallback, useContext, useState} from 'react';
 import Create from './Create';
 import {Timestamp, doc, getFirestore, updateDoc,} from 'firebase/firestore';
 import {AuthContext} from '../firebase/authContext';
@@ -22,6 +23,7 @@ import {removeStopwords} from 'stopword';
 import {TouchableOpacity} from 'react-native';
 import {useAppDispatch, useAppSelector} from '../Store/hooks';
 import {editLog} from '../Store/logs';
+import { useFocusEffect } from '@react-navigation/native';
 
 type Nav = NativeStackScreenProps<RootStackParamsList, 'Dream'>;
 
@@ -35,6 +37,17 @@ const Dream = ({route, navigation}: Nav) => {
   const dream = useAppSelector((state) => state.logs[index]);
   const dispatch = useAppDispatch();
 
+  useFocusEffect(useCallback(()=>{
+    const onBackPress = ()=>{
+      if(edit){
+        setEdit(false);
+        return true;
+      }
+      return false
+    }
+    const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+    return ()=>subscription.remove();
+  },[edit]))
   const editDream = (log: UploadLog) => {
     
     Alert.alert(

--- a/Screens/DreamList.tsx
+++ b/Screens/DreamList.tsx
@@ -16,8 +16,7 @@ import {
   doc,
   updateDoc,
 } from 'firebase/firestore';
-import React, {useCallback} from 'react';
-import {useEffect, useContext, useRef, useState} from 'react';
+import {useEffect, useContext, useRef, useState, useCallback} from 'react';
 import {
   Text,
   View,
@@ -30,12 +29,13 @@ import {
   Keyboard,
   TextInput,
   Alert,
+  BackHandler,
 } from 'react-native';
 import {Log, RootStackParamsList, TabParamsList} from '../types';
 import {AuthContext} from '../firebase/authContext';
 import {fb} from '../firebase/firebaseConfig';
 import appColors from '../colors';
-import type {CompositeScreenProps} from '@react-navigation/native';
+import {useFocusEffect, type CompositeScreenProps} from '@react-navigation/native';
 import type {BottomTabScreenProps} from '@react-navigation/bottom-tabs';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import {Feather} from '@expo/vector-icons';
@@ -96,6 +96,17 @@ const DreamList = ({navigation}: DreamListScreenProps) => {
   const fetchesRemaining = useRef<boolean>(true);
   const searchBarRef = useRef<TextInput | null>(null);
   const callOnScrollEnd = useRef<boolean>(false);
+  useFocusEffect(useCallback(()=>{
+    const handleBackPress = () =>{
+      if(user){
+        BackHandler.exitApp()
+        return true;
+      }
+      return false
+    }
+    const subscription = BackHandler.addEventListener('hardwareBackPress', handleBackPress);
+    return ()=>subscription.remove();
+  },[user]))
   useEffect(() => {
     const fetch = async () => {
       if (user && fetchesRemaining.current && isRefreshingList) {


### PR DESCRIPTION
Changes what happens when the user presses the android back button on the dreamlist and dream page. On the dreamlist page, the app will now exit instead of returning to the login screen (which would just send the user right back to the dreamlist page because they were already signed in). On the dream page, if the user is in edit mode, the back button will now just kick them out of edit mode instead of returning to the previous page.